### PR TITLE
Fix sprite priority when overlapping pixels have different priority bits

### DIFF
--- a/C64/PixelEngine.cpp
+++ b/C64/PixelEngine.cpp
@@ -688,7 +688,7 @@ PixelEngine::setSpritePixel(unsigned pixelnr, int rgba, int depth, int source)
     unsigned offset = bufferoffset + pixelnr;
     assert(offset < NTSC_PIXELS);
     
-    if (depth <= zBuffer[pixelnr]) {
+    if (depth <= zBuffer[pixelnr] && !(pixelSource[pixelnr] & 0x7F)) {
         pixelBuffer[offset] = rgba;
         zBuffer[pixelnr] = depth;
     }


### PR DESCRIPTION
According to https://sourceforge.net/p/vice-emu/code/HEAD/tree/testprogs/VICII/spritepriorities "when eg sprite 1 and sprite 0 overlap, and sprite 0 has the priority bit set (and sprite 1 has not). in this case 10/11 background bits show in front of whole sprite 0"
Now the output matches the reference image