### PR TITLE
Reset the expansion flipflop if the bit is changed to 0

### DIFF
--- a/C64/PixelEngine.cpp
+++ b/C64/PixelEngine.cpp
@@ -464,6 +464,8 @@ PixelEngine::drawSpritePixel(unsigned spritenr, unsigned pixelnr, bool freeze, b
             // Toggle horizontal expansion flipflop for stretched sprites
             if (GET_BIT(pipe.spriteXexpand, spritenr))
                 sprite_sr[spritenr].exp_flop = !sprite_sr[spritenr].exp_flop;
+            else
+                sprite_sr[spritenr].exp_flop = true;
 
             // Run shift register and toggle multicolor flipflop
             if (sprite_sr[spritenr].exp_flop) {


### PR DESCRIPTION
Fixes MC4 from vicii_timing (when expansion is disabled halfway through a single expanded pixel, the flipflop would never reset and keep outputting the same pixel)