### PR TITLE
Minor GUI inprovments

### DIFF
--- a/GUI/KeyboardController.swift
+++ b/GUI/KeyboardController.swift
@@ -141,6 +141,7 @@ class KeyboardController: NSObject {
 
         // Positional key mapping
         if pref.mapKeysByPosition {
+            parent.virtualKeyboard?.refresh();
             keyDown(with: macKey, keyMap: pref.keyMap)
             return
         }

--- a/GUI/KeyboardController.swift
+++ b/GUI/KeyboardController.swift
@@ -158,6 +158,7 @@ class KeyboardController: NSObject {
                 keyboard.pressKey(atRow: key.row, col: key.col)
             }
         }
+        parent.virtualKeyboard?.refresh();
     }
     
     func keyDown(with macKey: MacKey, keyMap: [MacKey: C64Key]) {
@@ -191,6 +192,7 @@ class KeyboardController: NSObject {
                 keyboard.releaseKey(atRow: key.row, col: key.col)
             }
         }
+        parent.virtualKeyboard?.refresh();
     }
     
     func keyUp(with macKey: MacKey, keyMap: [MacKey: C64Key]) {

--- a/GUI/MyControllerMenu.swift
+++ b/GUI/MyControllerMenu.swift
@@ -484,8 +484,9 @@ extension MyController: NSMenuItemValidation {
             track("Virtual keyboard already open")
         } else {
             track("Opeining virtual keyboard as a window")
-            virtualKeyboard?.showWindow()
         }
+
+        virtualKeyboard?.showWindow()
     }
     
     @IBAction func clearKeyboardMatrixAction(_ sender: Any!) {

--- a/XIB files/Inspector.xib
+++ b/XIB files/Inspector.xib
@@ -241,12 +241,13 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Inspector" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g">
+        <window title="Inspector" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="QvC-M9-y7g">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="868" height="476"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1536" height="935"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2048" height="1127"/>
             <value key="minSize" type="size" width="868" height="468"/>
+            <value key="maxSize" type="size" width="868" height="4096"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="868" height="476"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -551,7 +552,7 @@
                                         </box>
                                         <box fixedFrame="YES" title="Program" translatesAutoresizingMaskIntoConstraints="NO" id="uH3-BT-rcU">
                                             <rect key="frame" x="6" y="0.0" width="267" height="378"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                             <view key="contentView" id="arw-qO-08J">
                                                 <rect key="frame" x="3" y="3" width="261" height="360"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -655,7 +656,7 @@
                                         </box>
                                         <box fixedFrame="YES" title="Trace" translatesAutoresizingMaskIntoConstraints="NO" id="qwA-pF-whQ">
                                             <rect key="frame" x="275" y="0.0" width="243" height="378"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                             <view key="contentView" id="qxq-ms-0ZY">
                                                 <rect key="frame" x="3" y="3" width="237" height="360"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/XIB files/Inspector.xib
+++ b/XIB files/Inspector.xib
@@ -1819,7 +1819,7 @@
                                         </textField>
                                         <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Gv7-DL-8x9">
                                             <rect key="frame" x="11" y="348" width="63" height="14"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Idle since:" id="pHZ-mh-lkL">
                                                 <font key="font" metaFont="message" size="11"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1843,7 +1843,7 @@
                                         </levelIndicator>
                                         <textField verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aY7-JT-p1h">
                                             <rect key="frame" x="602" y="345" width="98" height="14"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Overall idle time:" id="xN2-hJ-biM">
                                                 <font key="font" metaFont="message" size="11"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1872,10 +1872,10 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" drawsBackground="NO" id="uN2-KZ-pod">
                                                 <rect key="frame" x="1" y="1" width="628" height="194"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView focusRingType="exterior" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="15" headerView="Yjj-no-34g" id="9cm-34-eYe" customClass="MemTableView" customModule="VirtualC64" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="0.0" width="656" height="169"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="636" height="169"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -1933,8 +1933,8 @@
                                                 <rect key="frame" x="84" y="17" width="15" height="67"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
-                                            <tableHeaderView key="headerView" id="Yjj-no-34g">
-                                                <rect key="frame" x="0.0" y="0.0" width="656" height="25"/>
+                                            <tableHeaderView key="headerView" wantsLayer="YES" id="Yjj-no-34g">
+                                                <rect key="frame" x="0.0" y="0.0" width="636" height="25"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </tableHeaderView>
                                         </scrollView>
@@ -2196,7 +2196,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                             <clipView key="contentView" drawsBackground="NO" id="EqP-5S-dIY">
                                                 <rect key="frame" x="1" y="1" width="140" height="194"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView wantsLayer="YES" focusRingType="exterior" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="15" headerView="oYx-eh-0z5" id="Dol-9l-TFV" customClass="BankTableView" customModule="VirtualC64" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="140" height="169"/>
@@ -2217,7 +2217,7 @@
                                                                 </textFieldCell>
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             </tableColumn>
-                                                            <tableColumn identifier="source" editable="NO" width="67" minWidth="64" maxWidth="1000" id="cQo-K4-DWa">
+                                                            <tableColumn identifier="source" editable="NO" width="87" minWidth="64" maxWidth="1000" id="cQo-K4-DWa">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="center" title="Source">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" white="0.33333299" alpha="1" colorSpace="calibratedWhite"/>
@@ -3053,7 +3053,7 @@
                                         </box>
                                         <box fixedFrame="YES" title="Sprites" translatesAutoresizingMaskIntoConstraints="NO" id="Vy1-vO-GXi">
                                             <rect key="frame" x="552" y="2" width="264" height="211"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                             <view key="contentView" id="xpU-bX-3kA">
                                                 <rect key="frame" x="3" y="3" width="258" height="193"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -4024,10 +4024,10 @@
                                     <subviews>
                                         <scrollView fixedFrame="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="raT-oJ-cVx" customClass="DiskDataView" customModule="VirtualC64" customModuleProvider="target">
                                             <rect key="frame" x="275" y="41" width="530" height="296"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <clipView key="contentView" drawsBackground="NO" id="aIH-Gg-Lix">
                                                 <rect key="frame" x="1" y="1" width="528" height="294"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textView editable="NO" importsGraphics="NO" verticallyResizable="YES" usesFontPanel="YES" findStyle="panel" continuousSpellChecking="YES" usesRuler="YES" allowsNonContiguousLayout="YES" quoteSubstitution="YES" dashSubstitution="YES" spellingCorrection="YES" smartInsertDelete="YES" id="Z0G-5d-mCN">
                                                         <rect key="frame" x="0.0" y="0.0" width="528" height="294"/>
@@ -4057,7 +4057,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                             <clipView key="contentView" drawsBackground="NO" id="gvT-zI-kOz">
                                                 <rect key="frame" x="1" y="1" width="113" height="294"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView wantsLayer="YES" focusRingType="exterior" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="15" headerView="qMK-jo-JSe" id="QHD-zl-BVw" customClass="TrackTableView" customModule="VirtualC64" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="113" height="269"/>
@@ -4104,7 +4104,7 @@
                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" heightSizable="YES"/>
                                             <clipView key="contentView" drawsBackground="NO" id="qo3-j4-7on">
                                                 <rect key="frame" x="1" y="1" width="113" height="294"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView wantsLayer="YES" focusRingType="exterior" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="15" headerView="BSO-7Z-azM" id="fpd-S5-ZTi" customClass="SectorTableView" customModule="VirtualC64" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="113" height="269"/>
@@ -4148,7 +4148,7 @@
                                         </scrollView>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lgd-yC-XpT">
                                             <rect key="frame" x="677" y="15" width="102" height="16"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Seek drive head" id="B8v-9M-F1t">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -4157,7 +4157,7 @@
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JUA-He-SQg">
                                             <rect key="frame" x="275" y="14" width="297" height="17"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Warning: The GCR data stream contains errors" id="3se-jR-ZYb">
                                                 <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="systemRedColor" catalog="System" colorSpace="catalog"/>
@@ -4166,7 +4166,7 @@
                                         </textField>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="24y-UU-oAh">
                                             <rect key="frame" x="564" y="12" width="20" height="20"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSInfo" imagePosition="overlaps" alignment="center" state="on" imageScaling="proportionallyUpOrDown" inset="2" id="Lf3-zm-WX8">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -4177,7 +4177,7 @@
                                         </button>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xOE-7f-oq0">
                                             <rect key="frame" x="15" y="14" width="130" height="18"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                             <buttonCell key="cell" type="check" title="Include halftracks" bezelStyle="regularSquare" imagePosition="left" inset="2" id="JqB-7N-Anm">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -4188,7 +4188,7 @@
                                         </button>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PcX-yZ-FXg">
                                             <rect key="frame" x="785" y="12" width="20" height="20"/>
-                                            <autoresizingMask key="autoresizingMask" flexibleMinY="YES"/>
+                                            <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRevealFreestandingTemplate" imagePosition="overlaps" alignment="center" state="on" imageScaling="proportionallyUpOrDown" inset="2" id="Pff-cS-oKd">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES" accelerator="YES"/>
                                                 <font key="font" metaFont="system"/>


### PR DESCRIPTION
Inspector:

* Enlarge Program and Trace if window is resized.
* Fix position of certain elements
* Limit max width of the window.
* Disable autohide of the inspector.

Before:
<img width="50%" alt="Bildschirmfoto 2021-03-02 um 21 00 01" src="https://user-images.githubusercontent.com/111508/109707561-97639d00-7b9a-11eb-8ef7-92ab53557a5a.png">

<img width="839" alt="Bildschirmfoto 2021-03-02 um 21 06 24" src="https://user-images.githubusercontent.com/111508/109708107-443e1a00-7b9b-11eb-9148-4f41321b0d19.png">

<img width="303" alt="Bildschirmfoto 2021-03-02 um 21 06 41" src="https://user-images.githubusercontent.com/111508/109708119-47390a80-7b9b-11eb-976f-9f5678ed3eb7.png">

After:
<img width="50%" alt="Bildschirmfoto 2021-03-02 um 20 59 48" src="https://user-images.githubusercontent.com/111508/109707564-99c5f700-7b9a-11eb-8a70-dd24e113e58c.png">

Virtual keyboard:

* Bring virtual keyboard in front if it is in the background in hidden by another window.
* Highlight keypress on virtual keyboard if the window is open and the user press keys on the physical keyboard. (Modifiers are delayed)

<img width="785" alt="Bildschirmfoto 2021-03-02 um 21 01 48" src="https://user-images.githubusercontent.com/111508/109707827-ed384500-7b9a-11eb-8ade-df57a4e08078.png">




